### PR TITLE
Drop requirement for GNU parallel in pre-commit hook

### DIFF
--- a/.scripts/hooks/pre-commit
+++ b/.scripts/hooks/pre-commit
@@ -1,18 +1,13 @@
 #!/bin/bash
-
-runAndReportIfError() {
-  "${@:2}" > "${1}"
-  EXIT_CODE=$?
-  if [ $EXIT_CODE -ne 0 ]; then
-    cat >&2 "${1}"
-    return $EXIT_CODE
-  fi
-}
-export -f runAndReportIfError
+set -e
 
 REPORT_DIR="build/pre-commit"
 rm -rf $REPORT_DIR || true
 mkdir -p ${REPORT_DIR}
 
-parallel --halt now,done=1 ::: "runAndReportIfError ${REPORT_DIR}/ktlint.log ./.scripts/check_ktlint.sh"
-parallel --halt now,done=1 ::: "./gradlew clean build"
+BUILD_TASK_FILE=${REPORT_DIR}/build.log
+./gradlew build >> $BUILD_TASK_FILE || (cat $BUILD_TASK_FILE && exit 1) &
+KTLINT_TASK_FILE=${REPORT_DIR}/ktlint.log
+./.scripts/check_ktlint.sh >> $KTLINT_TASK_FILE || (cat $KTLINT_TASK_FILE && exit 1)
+
+wait


### PR DESCRIPTION
This also fixes an issue where hook commands would not actually run in parallel.