### PR TITLE
Fix pre-commit hook ignoring last command exit code

### DIFF
--- a/.scripts/hooks/pre-commit
+++ b/.scripts/hooks/pre-commit
@@ -13,7 +13,7 @@ TASK_FILE_KTLINT=${REPORT_DIR}/ktlint.log
 ./.scripts/check_ktlint.sh > $TASK_FILE_KTLINT 2>&1 &
 PIDSTOOUTPUTFILES+=("$!:$TASK_FILE_KTLINT")
 
-while [[ $(jobs -p) ]]
+while :
 do
   INDEX=-1
   for PIDTOOUTPUTFILE in "${PIDSTOOUTPUTFILES[@]}"; do
@@ -24,6 +24,9 @@ do
       if wait "$PID"; then
         unset 'PIDSTOOUTPUTFILES[$INDEX]'
         PIDSTOOUTPUTFILES=("${PIDSTOOUTPUTFILES[@]}")
+        if [ ${#PIDSTOOUTPUTFILES[@]} -eq 0 ]; then
+            exit 0
+        fi
       else
         jobs -p | xargs kill
         cat "${PIDTOOUTPUTFILE#*:}"


### PR DESCRIPTION
Because we stopped looping once there were no background processes left, we'd never consider what happened with the last one to finish.
