### PR TITLE
Use -module-name Kotlin/Native compiler argument to set custom ObjC prefix

### DIFF
--- a/buildlogic/src/main/kotlin/buildlogic/KotlinMultiplatformLibraryPluginExtension.kt
+++ b/buildlogic/src/main/kotlin/buildlogic/KotlinMultiplatformLibraryPluginExtension.kt
@@ -34,6 +34,7 @@ open class KotlinMultiplatformLibraryPluginExtension @Inject constructor(
             binaryOption("bundleShortVersionString", version as String)
             binaryOption("bundleVersion", version as String)
             isStatic = true
+            freeCompilerArgs += listOf("-module-name", "TNT")
             xCFramework.add(this)
           }
       }

--- a/changelog/1.0.2
+++ b/changelog/1.0.2
@@ -1,0 +1,1 @@
+Migrate to Kotlin/Native's compiler -module-name to specify custom Objective-C symbol prefix.

--- a/networktime/src/commonMain/kotlin/com/tidal/networktime/NTPServer.kt
+++ b/networktime/src/commonMain/kotlin/com/tidal/networktime/NTPServer.kt
@@ -26,7 +26,6 @@ import kotlin.time.Duration.Companion.seconds
  * dispersion higher than this will be discarded.
  * @param dnsResolutionTimeout The timeout for DNS lookup for addresses from [hostName].
  */
-@ObjCName(name = "TNTNTPServer", swiftName = "NTPServer", exact = true)
 class NTPServer(
   val hostName: String,
   @ObjCName(name = "queryConnectTimeoutMs")

--- a/networktime/src/commonMain/kotlin/com/tidal/networktime/NTPVersion.kt
+++ b/networktime/src/commonMain/kotlin/com/tidal/networktime/NTPVersion.kt
@@ -1,8 +1,5 @@
 package com.tidal.networktime
 
-import kotlin.native.ObjCName
-
-@ObjCName(name = "TNTNTPVersion", swiftName = "NTPVersion", exact = true)
 enum class NTPVersion {
   ZERO,
   ONE,

--- a/networktime/src/commonMain/kotlin/com/tidal/networktime/ProtocolFamily.kt
+++ b/networktime/src/commonMain/kotlin/com/tidal/networktime/ProtocolFamily.kt
@@ -1,11 +1,8 @@
 package com.tidal.networktime
 
-import kotlin.native.ObjCName
-
 /**
  * A designation of protocol families to discriminate resolved addresses on.
  */
-@ObjCName(name = "TNTProtocolFamily", swiftName = "ProtocolFamily", exact = true)
 enum class ProtocolFamily {
   /**
    * IPv4.

--- a/networktime/src/commonMain/kotlin/com/tidal/networktime/SNTPClient.kt
+++ b/networktime/src/commonMain/kotlin/com/tidal/networktime/SNTPClient.kt
@@ -20,7 +20,6 @@ import kotlin.time.Duration.Companion.seconds
  * packet has been received and processed. If not `null` but writing or reading fail when attempted,
  * program execution will continue as if it had been `null` until the next attempt.
  */
-@ObjCName(name = "TNTSNTPClient", swiftName = "SNTPClient", exact = true)
 class SNTPClient(
   vararg val ntpServers: NTPServer,
   @ObjCName(name = "synchronizationIntervalMs")
@@ -36,7 +35,7 @@ class SNTPClient(
   /**
    * The calculated epoch time if it has been calculated at least once or null otherwise.
    */
-  @ObjCName("epochTimeMs")
+  @ObjCName(name = "epochTimeMs")
   val epochTime by delegate::epochTime
 
   /**


### PR DESCRIPTION
ref: https://kotlinlang.org/docs/native-faq.html#how-do-i-specify-a-custom-objective-c-prefix-name-for-my-kotlin-framework